### PR TITLE
Created Bean of type RestTemplate

### DIFF
--- a/movie-catalog-service/movie-catalog-service/src/main/java/com/gizmosoft/moviecatalogservice/MovieCatalogServiceApplication.java
+++ b/movie-catalog-service/movie-catalog-service/src/main/java/com/gizmosoft/moviecatalogservice/MovieCatalogServiceApplication.java
@@ -2,10 +2,18 @@ package com.gizmosoft.moviecatalogservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 public class MovieCatalogServiceApplication {
 
+	// The below tells spring to create a Bean of type RestTemplate
+	// Whenever anything of type RestTemplate is called using @Autowired in this Spring Application, this instance of RestTemplate will be called and given to it because by default Spring Beans are Singleton (which create only one instance)
+	@Bean
+	public RestTemplate getRestTemplate(){
+		return new RestTemplate();
+	}
 	public static void main(String[] args) {
 		SpringApplication.run(MovieCatalogServiceApplication.class, args);
 		System.out.println("Created a Rest Controller!");

--- a/movie-catalog-service/movie-catalog-service/src/main/java/com/gizmosoft/moviecatalogservice/resources/MovieCatalogResource.java
+++ b/movie-catalog-service/movie-catalog-service/src/main/java/com/gizmosoft/moviecatalogservice/resources/MovieCatalogResource.java
@@ -3,6 +3,7 @@ package com.gizmosoft.moviecatalogservice.resources;
 import com.gizmosoft.moviecatalogservice.model.CatalogItem;
 import com.gizmosoft.moviecatalogservice.model.Movie;
 import com.gizmosoft.moviecatalogservice.model.Rating;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,11 +18,12 @@ import java.util.stream.Collectors;
 @RequestMapping("/catalog")
 public class MovieCatalogResource {
 
+    // We are calling the bean which we created
+    @Autowired
+    private RestTemplate restTemplate;
+
     @RequestMapping("/{userId}")
     public List<CatalogItem> getCatalog(@PathVariable("userId") String userId){
-
-        RestTemplate restTemplate = new RestTemplate();
-
         // get ID of rated movies - hard coding using the Rating model
         List<Rating> ratings = Arrays.asList(
                 new Rating("1234", 4),

--- a/movie-catalog-service/movie-catalog-service/src/main/java/com/gizmosoft/moviecatalogservice/resources/MovieCatalogResource.java
+++ b/movie-catalog-service/movie-catalog-service/src/main/java/com/gizmosoft/moviecatalogservice/resources/MovieCatalogResource.java
@@ -26,6 +26,7 @@ public class MovieCatalogResource {
         List<Rating> ratings = Arrays.asList(
                 new Rating("1234", 4),
                 new Rating("5678", 3)
+        );
 
         return ratings.stream().map(rating -> {
             Movie movie = restTemplate.getForObject("http://localhost:8082/movies/" + rating.getMovieId(), Movie.class);


### PR DESCRIPTION
RestTemplate was being initialized multiple times and object was being created whenever there was a page reload which could be avoided by creating a bean of type RestTemplate and passing the same instance to Spring whenever it is requested. We can do this by @Autowired keyword and consume the created bean whenever necessary.